### PR TITLE
Handle missing `items` key in API response

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -43,7 +43,7 @@ exports.sourceNodes = async (
       `channels?part=contentDetails&id=${channelId}&key=${apiKey}`
     );
 
-    const channelData = channelResp.data.items[0];
+    const channelData = channelResp.data.items && channelResp.data.items[0];
     if (!!channelData) {
       const uploadsId = get(
         channelData,


### PR DESCRIPTION
The plugin assumes presence of `items` key. Due to an issue with YouTube
API, neither the key, nor the values are present:

https://issuetracker.google.com/issues/196063115

Expected API response looks like this:

https://developers.google.com/youtube/v3/docs/channels/list?apix_params=%7B%22part%22%3A%5B%22snippet%22%5D%2C%22id%22%3A%5B%22UC7Pq_fszTaPuIkYoqLmfDEA%22%5D%7D#response

The actual response is:

```
{
  "kind": "youtube#channelListResponse",
  "etag": "RuuXzTIr0OoDqI4S0RU6n4FqKEM",
  "pageInfo": {
    "totalResults": 0,
    "resultsPerPage": 5
  }
}
```

Note that `items` key is missing from the API response.

The plugin expected `items` key to be present:

https://github.com/bene/gatsby-source-youtube-v3/blob/main/src/gatsby-node.js#L46

```
const channelData = channelResp.data.items[0];
```

Current implementation results in an error:

```
 ERROR 

TypeError: Cannot read property '0' of undefined
    at _callee$
(/Users/[...]/node_modules/gatsby-source-youtube-v3/gatsby-node.js:74:61)
    at tryCatch (/Users/[...]/node_modules/gatsby-remark-images/node_modules/reg
enerator-runtime/runtime.js:63:40)
    at Generator.invoke [as _invoke] (/Users/[...]/node_modules/gatsby-remark-im
ages/node_modules/regenerator-runtime/runtime.js:294:22)
    at Generator.next (/Users/[...]/node_modules/gatsby-remark-images/node_modul
es/regenerator-runtime/runtime.js:119:21)
    at step
(/Users/[...]/node_modules/gatsby-source-youtube-v3/gatsby-node.js:5:191)
    at /Users/[...]/node_modules/gatsby-source-youtube-v3/gatsby-node.js:5:361
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)

not finished source and transform nodes - 129.494s

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With this change in place, `items` key not being present no longer breaks builds